### PR TITLE
replace elixir-lang.jp with elixir-lang.org

### DIFF
--- a/data/modan_tech.json
+++ b/data/modan_tech.json
@@ -47,7 +47,7 @@
                 "id" : "8",
                 "name" : "Elixir",
                 "image" : "img/elixir.jpeg",
-                "url" : "https://elixir-lang.jp/docs.html"
+                "url" : "https://elixir-lang.org/docs.html"
             },
             {
                 "id" : "9",
@@ -104,7 +104,7 @@
                 "id" : "8",
                 "name" : "Elixir",
                 "image" : "img/elixir.jpeg",
-                "url" : "https://elixir-lang.jp/getting-started/introduction.html"
+                "url" : "https://elixir-lang.org/getting-started/introduction.html"
             },
             {
                 "id" : "9",


### PR DESCRIPTION
.jp site the latest elixir version is 1.7, but now the latest one is 1.10.

- .jpサイトはElixirのバージョンが1.7となっていて少し古く今の最新は1.10なので、.orgに書き直しました。
- アプリケーションの動作確認はしていません
- ファイル名はモダンのつづりが modern_tech.json かなあとおもいましたがそこを変えると動作確認もしないと自信持ってだせないのでとりあえず.jsonの中だけ変えたプルリクを作ってみました